### PR TITLE
Just added a workflow for creating releases on push to main branch

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,28 @@
+name: Create Release on Push to Main
+
+on:
+  push:
+    branches:
+      - main 
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          body: |
+            Automated release based on push to main.
+            Commit: ${{ github.sha }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the creation of releases whenever there is a push to the `main` branch.

### Workflow Automation:

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R1-R28): Introduced a new workflow named "Create Release on Push to Main." This workflow triggers on pushes to the `main` branch and uses the `softprops/action-gh-release` action to create a release. The release includes the run number as the tag and name, and the commit SHA in the release body.